### PR TITLE
Change for macOS so that temp files created during "local encoding" are in "~/Library/Caches/ElectronWMD" location

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -177,12 +177,12 @@ function setupEncoder() {
     ipcMain.handle("invokeLocalEncoder", async (_, ffmpegPath: string, encoderPath: string, data: ArrayBuffer, sourceFilename: string, parameters: { format: Codec, enableReplayGain?: boolean }) => {
         // Pipeline:
         // inFile.ANY ==(ffmpeg)==> inFile.wav ==(encoder)==> outFile.wav
-        const tempDir = "";
+        let tempDir = '';
         if ( os.platform() === 'darwin') {
             const homeDir = app.getPath('home');
-            const tempDir = path.join(homeDir, 'Library','Caches','ElectronWMD');
+            tempDir = path.join(homeDir, 'Library','Caches','ElectronWMD');
         } else {
-            const tempDir = fs.mkdtempSync('atracenc');
+            tempDir = fs.mkdtempSync('atracenc');
         }
 
         if (!fs.existsSync(tempDir)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { DevicesIds as  NetMDDevicesIds } from 'netmd-js';
 import { DevicesIds as  HiMDDevicesIds } from 'himd-js';
 import { DeviceIds as NWDevicesIds, importKeys } from 'networkwm-js';
 import path from 'path';
+import os from 'os';
 import fs from 'fs';
 import { EWMDHiMD, EWMDNetMD } from './wmd/translations';
 import { Codec, NetMDFactoryService } from './wmd/original/services/interfaces/netmd';
@@ -176,7 +177,17 @@ function setupEncoder() {
     ipcMain.handle("invokeLocalEncoder", async (_, ffmpegPath: string, encoderPath: string, data: ArrayBuffer, sourceFilename: string, parameters: { format: Codec, enableReplayGain?: boolean }) => {
         // Pipeline:
         // inFile.ANY ==(ffmpeg)==> inFile.wav ==(encoder)==> outFile.wav
-        const tempDir = fs.mkdtempSync('atracenc');
+        const tempDir = "";
+        if ( os.platform() === 'darwin') {
+            const homeDir = app.getPath('home');
+            const tempDir = path.join(homeDir, 'Library','Caches','ElectronWMD');
+        } else {
+            const tempDir = fs.mkdtempSync('atracenc');
+        }
+
+        if (!fs.existsSync(tempDir)) {
+            fs.mkdirSync(tempDir);
+        }
         const inFilePath = path.join(tempDir, sourceFilename);
         fs.writeFileSync(inFilePath, new Uint8Array(data));
         const intermediateFilePath = path.join(tempDir, "intermediate.wav");


### PR DESCRIPTION
Not "you guys"...Apple "security stuff"

To make this easier and more "seamless" for (advanced) macOS users, ~/Library/Caches/ElectronWMD is used instead of the "System $TMPDIR" that would be exposed - due to "sandboxing" etc, the user may not have permission to write there. This is not an issue when ~/Library/Caches is used, and is the "preferred way" to do this on macOS.